### PR TITLE
Add 705600 and 768000 to supported rates

### DIFF
--- a/camilladsp/camilladsp.py
+++ b/camilladsp/camilladsp.py
@@ -21,6 +21,8 @@ STANDARD_RATES = [
     192000,
     352800,
     384000,
+    705600,
+    768000,
 ]
 
 class ProcessingState(Enum):


### PR DESCRIPTION
Verified on Linux. Those rates work well